### PR TITLE
Added 'ERROR' to stop thermo strings

### DIFF
--- a/lammps_logfile/File.py
+++ b/lammps_logfile/File.py
@@ -14,7 +14,7 @@ class File:
     def __init__(self, ifile):
         # Identifiers for places in the log file
         self.start_thermo_strings = ["Memory usage per processor", "Per MPI rank memory allocation"]
-        self.stop_thermo_strings = ["Loop time"]
+        self.stop_thermo_strings = ["Loop time", "ERROR"]
         self.data_dict = {}
         self.keywords = []
         self.output_before_first_run = ""


### PR DESCRIPTION
Added 'ERROR' to stop thermo strings to avoid bugs when reading crashed log files.