### PR TITLE
To pandas and update stop keywords

### DIFF
--- a/lammps_logfile/File.py
+++ b/lammps_logfile/File.py
@@ -1,6 +1,8 @@
+from io import BytesIO, StringIO
+
 import numpy as np
 import pandas as pd
-from io import BytesIO, StringIO
+
 
 class File:
     """Class for handling lammps log files.
@@ -14,7 +16,7 @@ class File:
     def __init__(self, ifile):
         # Identifiers for places in the log file
         self.start_thermo_strings = ["Memory usage per processor", "Per MPI rank memory allocation"]
-        self.stop_thermo_strings = ["Loop time", "ERROR"]
+        self.stop_thermo_strings = ["Loop time", "ERROR", "Fix halt condition"]
         self.data_dict = {}
         self.keywords = []
         self.output_before_first_run = ""
@@ -38,7 +40,7 @@ class File:
             if keyword_flag:
                 keywords = line.split()
                 tmpString = ""
-                # Check wheter any of the thermo stop strigs are in the present line
+                # Check wheter any of the thermo stop strings are in the present line
                 while not sum([string in line for string in self.stop_thermo_strings]) >= 1:
                     if "\n" in line:
                         tmpString+=line
@@ -119,6 +121,8 @@ class File:
                 key = key.replace("/", ".")
                 subgroup.create_dataset(key, data=value)
 
+    def to_dataframe(self, run_num=-1):
+        return pd.DataFrame(self.partial_logs[run_num])
 
 
     def get_num_partial_logs(self):

--- a/lammps_logfile/cmd_interface.py
+++ b/lammps_logfile/cmd_interface.py
@@ -9,6 +9,7 @@ def get_parser():
     parser.add_argument("-x", type=str, default="Time", help="Data to plot on the first axis")
     parser.add_argument("-y", type=str, nargs="+", help="Data to plot on the second axis. You can supply several names to get several plot lines in the same figure.")
     parser.add_argument("-a", "--running_average", type=int, default=1, help="Optionally average over this many log entries with a running average. Some thermo properties fluctuate wildly, and often we are interested in te running average of properties like temperature and pressure.")
+    parser.add_argument("-o", type=str, dest='fout', default='', help='Save the figure to this file; the format must be supported by matplotlib.')
     return parser
 
 def run():
@@ -27,4 +28,6 @@ def run():
         plt.plot(x, data, label=y)
     plt.legend()
     plt.show()
-    
+    if args.fout != '':
+        plt.savefig(args.fout, dpi=300)
+


### PR DESCRIPTION
I added a simple method to convert the (partial) logs into a pandas dataframe.

Using a fix to halt a LAMMPS simulation based on some condition [may print a message](https://docs.lammps.org/fix_halt.html#fix-halt-command) during logging. The output may look something like:
```
     16000   1.6           -2187.7072     -2202.9871      15.279821     -2186.1222      2.0830044      16.562962      9.6987109      17.514459      2813.512       39343.476      17488.992     -54124.623      902.61501    
Fix halt condition for fix-id halt_dist met on step 16500 with value 0.03835776466582203 (src/fix_halt.cpp:240)
     16500   1.65          -2205.6255     -2225.1848      19.559372     -2203.9005      2.1125844      16.485295      9.6532315      17.43233       2774.1177      30917.654      19979.885     -47908.86       996.22635
```
The first three words of the message line are added to the `stop_thermo_strings`. The line after the message is (currently) being dropped.

